### PR TITLE
Fix the set owned filtering if a user is a local administrator, and the report generation.

### DIFF
--- a/pycobalthound.py
+++ b/pycobalthound.py
@@ -929,7 +929,7 @@ def beacon_investigate(dialog, button_name, values):
                 system = True
             # This will exclude the "Administrator" DA in AD too, but I guess you don't need to investigate if you've got a high integrity beacon as that :)
             elif user == "Administrator *":
-                system == True
+                system = True
             else:
                 system = False
 
@@ -1000,7 +1000,7 @@ def mark_owned_action(dialog, button_name, values):
             if user == "SYSTEM *":
                 system = True
             elif user == "Administrator *":
-                system == True
+                system = True
             else:
                 system = False
             # Format user/computer names

--- a/report.py
+++ b/report.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import time
 # HTML templates
 
@@ -95,6 +94,7 @@ def parse_results(user_results, computer_results):
   return html
 
 def generate_html_report(user_results, computer_results):
+  report = ''
   if all(len(result['result']) == 0 for result in user_results) == False or all(len(result['result']) == 0 for result in computer_results) == False:
     inner_html = parse_results(user_results, computer_results)
     report = top + title + time.strftime("%Y-%m-%d %H:%M:%S") + '</h3>' + inner_html + bot


### PR DESCRIPTION
Hi,

This pull request fixes two issues:

1. the `system` variable was not set correctly if a username is `Administrator`.
2. the `report` variable is not set if no results are found.